### PR TITLE
update mozrank column name to SF default

### DIFF
--- a/Tutorials/PageRankandCheiRank.ipynb
+++ b/Tutorials/PageRankandCheiRank.ipynb
@@ -126,7 +126,7 @@
     "            \n",
     "        df_html_200 = df_html_200.append(row, ignore_index=True)\n",
     "    \n",
-    "    df_html_200 = df_html_200.groupby(['Address'], as_index=False).agg({'Moz MozRank External Equity - Exact': 'sum', 'Outlinks':'max'})\n",
+    "    df_html_200 = df_html_200.groupby(['Address'], as_index=False).agg({'Moz External Equity Links - Exact': 'sum', 'Outlinks':'max'})\n",
     "    \n",
     "    # Create mapping for redirects\n",
     "    redirect_statuses = [301,302]\n",
@@ -178,7 +178,7 @@
     "# Grab 200 urls and canonicalize\n",
     "df_html, mappings = consolidate_urls(df_html)\n",
     "\n",
-    "df_html = df_html[['Address','Moz MozRank External Equity - Exact', 'Outlinks']]\n",
+    "df_html = df_html[['Address','Moz External Equity Links - Exact', 'Outlinks']]\n",
     "df_html.columns = ['Address', 'Equity', 'Outlinks']\n",
     "df_html.head()"
    ]


### PR DESCRIPTION
Update column heading name from "Moz MozRank External Equity - Exact" to "Moz External Equity Links - Exact" to correct a key error. This is the current default internal_html.csv column heading name for SF 11.3